### PR TITLE
fix: handle case where keyup is not fired when meta is pressed

### DIFF
--- a/src/__tests__/index.tsx
+++ b/src/__tests__/index.tsx
@@ -296,7 +296,15 @@ describe('react-keybind', () => {
         fireEvent.keyDown(node, { key: 'a', metaKey: true });
         fireEvent.keyUp(node, { key: 'a', metaKey: true });
 
-        expect(method).toHaveBeenCalledTimes(4);
+        // NOTE: in macos while the meta key is pressed no other key's keyup event is fired
+        fireEvent.keyDown(node, { key: 'Meta' })
+        fireEvent.keyDown(node, { key: 'a' })
+        fireEvent.keyUp(node, { key: 'Meta' });
+
+        fireEvent.keyDown(node, { key: 'z', altKey: true });
+        fireEvent.keyUp(node, { key: 'z', altKey: true });
+
+        expect(method).toHaveBeenCalledTimes(6);
       });
 
       it('detects alternative modifier keys', () => {
@@ -564,7 +572,7 @@ describe('react-keybind', () => {
 
       it('executes a shortcut when an element is being dragged', () => {
         const DragComponent = () => {
-          const onDragStart = useCallback((event) => {}, []) as DragEventHandler<HTMLDivElement>;
+          const onDragStart = useCallback(() => {}, []) as DragEventHandler<HTMLDivElement>;
           return (
               <div data-testid="drag" draggable="true" onDragStart={onDragStart}>Drag this</div>
           )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -274,6 +274,8 @@ export const ShortcutProvider = memo(
       }
       if (key === 'meta' || e.metaKey) {
         keysUp.push('meta');
+        // NOTE: in macos if meta key is pressed no other key's keyup is fired
+        keysDown.current = []
       }
       if (key === 'shift' || e.shiftKey) {
         keysUp.push('shift');


### PR DESCRIPTION
In macos, while `cmd` (that is meta key) is pressed no other key's keyup event is fired. This PR adds a test case for same and fixes it.

fixes: https://github.com/dddice/react-keybind/issues/576